### PR TITLE
Verbose serverstatus

### DIFF
--- a/src/algosound/data/algorithms/Algorithm.java
+++ b/src/algosound/data/algorithms/Algorithm.java
@@ -15,6 +15,9 @@ public interface Algorithm {
     // Name of algorithm
     String getString();
 
+    // Suffix of algorithm
+    String getSuffix();
+
     // Start the algorithm
     void start();
 

--- a/src/algosound/data/algorithms/Bubblesort.java
+++ b/src/algosound/data/algorithms/Bubblesort.java
@@ -18,11 +18,14 @@ import static processing.core.PApplet.map;
  */
 public class Bubblesort extends SortingAlgorithm {
 
+    // Static field for access during creation of sonifications.
+    // This cannot be static in SortingAlgorithm since all subclasses need their own definition of this.
     public static final String SUFFIX = "BUBBLESORT";
 
     public Bubblesort(int N) {
         super(N);
         name = "Bubblesort";
+        suffix = SUFFIX;
         sonifications.add(BUBBLESORT_WAVE);
         sonifications.add(BUBBLESORT_SCALE);
         selected_sonification = sonifications.get(0);

--- a/src/algosound/data/algorithms/Insertionsort.java
+++ b/src/algosound/data/algorithms/Insertionsort.java
@@ -21,11 +21,14 @@ import static algosound.util.AlgosoundUtil.expmap;
  */
 public class Insertionsort extends SortingAlgorithm {
 
+    // Static field for access during creation of sonifications.
+    // This cannot be static in SortingAlgorithm since all subclasses need their own definition of this.
     public static final String SUFFIX = "INSERTIONSORT";
 
     public Insertionsort(int N) {
         super(N);
         name = "Insertionsort";
+        suffix = SUFFIX;
         sonifications.add(INSERTIONSORT_WAVE);
         sonifications.add(INSERTIONSORT_SCALE);
         selected_sonification = sonifications.get(0);

--- a/src/algosound/data/algorithms/Mergesort.java
+++ b/src/algosound/data/algorithms/Mergesort.java
@@ -26,7 +26,10 @@ import static processing.core.PApplet.*;
  */
 public class Mergesort extends SortingAlgorithm {
 
+    // Static field for access during creation of sonifications.
+    // This cannot be static in SortingAlgorithm since all subclasses need their own definition of this.
     public static final String SUFFIX = "MERGESORT";
+
     // Variables to pass mergesort() to determine mode.
     final static byte NATIVE = 1;
     final static byte THREAD = 2;
@@ -46,6 +49,7 @@ public class Mergesort extends SortingAlgorithm {
         // Needed for proper cut index and subset visualization.
         cutStack.push(0);
         name = "Mergesort";
+        suffix = SUFFIX;
         sonifications.add(MERGESORT_WAVE);
         sonifications.add(MERGESORT_SCALE);
         selected_sonification = sonifications.get(0);

--- a/src/algosound/data/algorithms/Quicksort.java
+++ b/src/algosound/data/algorithms/Quicksort.java
@@ -26,6 +26,8 @@ import static processing.core.PApplet.subset;
  */
 public class Quicksort extends SortingAlgorithm {
 
+    // Static field for access during creation of sonifications.
+    // This cannot be static in SortingAlgorithm since all subclasses need their own definition of this.
     public static final String SUFFIX = "QUICKSORT";
 
     private QuicksortElement[] elements;
@@ -38,6 +40,7 @@ public class Quicksort extends SortingAlgorithm {
     public Quicksort(int N) {
         super(N);
         name = "Quicksort";
+        suffix = SUFFIX;
         elements = QuicksortElement.createElements(N, Algosound.getInstance());
         a = Element.getValues(elements);
         unmarkMe = new ArrayList<QuicksortElement>();

--- a/src/algosound/data/algorithms/Selectionsort.java
+++ b/src/algosound/data/algorithms/Selectionsort.java
@@ -19,11 +19,14 @@ import static processing.core.PApplet.map;
  */
 public class Selectionsort extends SortingAlgorithm {
 
+    // Static field for access during creation of sonifications.
+    // This cannot be static in SortingAlgorithm since all subclasses need their own definition of this.
     public static final String SUFFIX = "SELECTIONSORT";
 
     public Selectionsort(int N) {
         super(N);
         name = "Selectionsort";
+        suffix = SUFFIX;
         sonifications.add(SELECTIONSORT_WAVE);
         sonifications.add(SELECTIONSORT_SCALE);
         selected_sonification = sonifications.get(0);

--- a/src/algosound/data/algorithms/SortingAlgorithm.java
+++ b/src/algosound/data/algorithms/SortingAlgorithm.java
@@ -32,6 +32,8 @@ public abstract class SortingAlgorithm extends Thread implements Algorithm {
     public final static SortingAlgorithm QUICKSORT = new Quicksort(N);
     // Name of sorting algorithm to display in info area.
     protected String name;
+    // Used suffix for uniquifying sonifications.
+    protected String suffix;
     // Array which should be sorted.
     protected int[] a;
     // Elements which have to be swapped according to integers.
@@ -76,6 +78,10 @@ public abstract class SortingAlgorithm extends Thread implements Algorithm {
 
     public String getString() {
         return name;
+    }
+
+    public String getSuffix() {
+        return suffix;
     }
 
     public boolean frameIsReady() {

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -12,6 +12,9 @@ import oscP5.OscMessage;
 import oscP5.OscP5;
 import processing.core.PApplet;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Open sound control file. All methods and logic about sending and receiving of
  * OSC messages is implemented here. Extends PApplet to be able to receive
@@ -22,6 +25,10 @@ import processing.core.PApplet;
  * @date 17/02/2018
  */
 public class OSC extends PApplet {
+    private interface LambdaInterface {
+        void call(String s1);
+    }
+
     private static OSC instance;
 
     private final OscP5 OSC;
@@ -29,10 +36,8 @@ public class OSC extends PApplet {
     private final int SC_PORT = 57120;
     private final int OSC_PORT = 12000;
 
-    // Status of connection.
-    private boolean connected;
-    // SuperCollider status reply.
-    private final String SC_REPLY = "/hello";
+    // Status of connections
+    Map<String, Boolean> connected = new HashMap<String, Boolean>();
     // Osc address of listeners.
     private String STATUS;
 
@@ -45,16 +50,40 @@ public class OSC extends PApplet {
     private OSC() {
         OSC = new OscP5(this, OSC_PORT);
         SUPERCOLLIDER = new NetAddress("127.0.0.1", SC_PORT);
-        connected = false;
+        Sonification sonification = Algosound.getInstance().getAlgorithm().getSelectedSonification();
         // Send boot message.
-        sendMessage(Algosound.getInstance().getAlgorithm().getSelectedSonification().BOOTPATH);
+        sendMessage(sonification.BOOTPATH);
         // Start a thread which periodically checks if sc3-server is still running.
         status = new Thread() {
             @Override
             public void run() {
-                System.out.print(TIMEFORMAT.format(new java.util.Date()));
-                System.out.println("PROCESS @ checkSC3Status started.");
+                String s = TIMEFORMAT.format(new java.util.Date());
+                s += "PROCESS @ checkSC3Status started.";
+                //System.out.print(TIMEFORMAT.format(new java.util.Date()));
+                //System.out.println("PROCESS @ checkSC3Status started.");
+                System.out.println(s);
+                LambdaInterface resetPathStatus = (String p) -> {
+                    // reset status
+                    connected.put(p, false);
+                    // send message to see if OSCdef replies
+                    sendMessage(p, "status");
+                };
                 while (!isInterrupted()) {
+                    // Update sonification (has maybe been changed)
+                    Sonification sonification = Algosound.getInstance().getAlgorithm().getSelectedSonification();
+                    String[] paths = {sonification.STATUSPATH,
+                            sonification.STARTPATH,
+                            sonification.PAUSEPATH,
+                            sonification.RESUMEPATH,
+                            sonification.FREEPATH,
+                            sonification.BOOTPATH,
+                    };
+                    for(String p : paths) {
+                        resetPathStatus.call(p);
+                    }
+                    for(String mod : sonification.MODPATHS) {
+                        resetPathStatus.call(mod);
+                    }
                     /**
                      * TODO: This implementation depends on order of execution. If 1. connected gets
                      * set to false, 2. a frame gets drawn, the ICP status is marked as lost in the
@@ -62,8 +91,7 @@ public class OSC extends PApplet {
                      * connected to false before checking the sc3-server. (Another 'connected'
                      * variable could work, but would be messy?)
                      */
-                    connected = false;
-                    sendMessage(Algosound.getInstance().getAlgorithm().getSelectedSonification().STATUSPATH);
+                    // Send messages to detect if other OSCdefs are also responding.
                     try {
                         sleep(1000);
                     } catch (InterruptedException e) {
@@ -71,20 +99,24 @@ public class OSC extends PApplet {
                         this.interrupt();
                     }
                 }
-                System.out.print(TIMEFORMAT.format(new java.util.Date()));
-                System.out.println("PROCESS @ checkSC3Status stopped.");
+                s = TIMEFORMAT.format(new java.util.Date());
+                s += "PROCESS @ checkSC3Status stopped.";
+                //System.out.print(TIMEFORMAT.format(new java.util.Date()));
+                //System.out.println("PROCESS @ checkSC3Status stopped.");
+                System.out.println(s);
             }
         };
         status.start();
     }
 
     // Listen for messages.
+    // NOTE we only expect status replies
     public void oscEvent(OscMessage msg) {
-        System.out.print(TIMEFORMAT.format(new java.util.Date()));
-        System.out.println("OSC @ RECV_MSG: " + msg.addrPattern());
-        // SC3 will fire SC_REPLY-message if OSC did fire OSC_STATUS-message.
-        if (msg.checkAddrPattern(SC_REPLY))
-            connected = true;
+        String s = TIMEFORMAT.format(new java.util.Date());
+        s += "OSC @ RECV_MSG: " + msg.addrPattern();
+        System.out.println(s);
+        // SC3 will reply with path of received OSCdef
+        connected.put(msg.addrPattern(), true);
     }
 
     /**
@@ -94,66 +126,59 @@ public class OSC extends PApplet {
      * @args arguments within osc message
      */
     public void sendMessage(String path, int[] args) {
-        System.out.print(TIMEFORMAT.format(new java.util.Date()));
-        System.out.print("OSC @ SEND_MSG to: " + path);
+        String s = TIMEFORMAT.format(new java.util.Date());
+        s += "OSC @ SEND_MSG to: " + path;
         OscMessage msg = new OscMessage(path);
-        System.out.print(", ARGS: [ ");
+        s += ", ARGS: [ ";
         for (int n : args) {
             msg.add(n);
-            System.out.print(n + " ");
+            s += n + " ";
         }
-        System.out.print("]");
-        if (OSC != null)
+        s += "]";
+        if (OSC != null) {
             OSC.send(msg, SUPERCOLLIDER);
-        else System.err.print(" FAILED SENDING MESSAGE");
-        System.out.println();
+            System.out.println(s);
+        }
+        else System.err.println(s + " FAILED SENDING MESSAGE");
     }
 
     public void sendMessage(String path, float[] args) {
-        System.out.print(TIMEFORMAT.format(new java.util.Date()));
-        System.out.print("OSC @ SEND_MSG to: " + path);
+        String s = TIMEFORMAT.format(new java.util.Date());
+        s += "OSC @ SEND_MSG to: " + path;
         OscMessage msg = new OscMessage(path);
-        System.out.print(", ARGS: [ ");
+        s += ", ARGS: [ ";
         for (float n : args) {
             msg.add(n);
-            System.out.print(n + " ");
+            s += n + " ";
         }
-        System.out.print("]");
-        if (OSC != null)
+        s += "]";
+        if (OSC != null) {
             OSC.send(msg, SUPERCOLLIDER);
-        else System.err.print(" FAILED SENDING MESSAGE");
-        System.out.println();
+            System.out.println(s);
+        }
+        else System.err.println(s + " FAILED SENDING MESSAGE");
     }
 
-    /**
-     * Send a message to an osc listener with given path and arguments (generic-version).
-     * Does not work because java primitives like int and float are no real "Types" like Number.
-     *
-     * @param path path to osc listener.
-     */
-    /*
-    public <T> void sendMessage(String path, T[] args) {
-        System.out.println("osc: sending message to: " + path);
-        OscMessage msg = new OscMessage(path);
-        System.out.print("--- arguments[ ");
-        for (T n : args) {
-            float add = (float) n;
-            msg.add((float) n);
-            System.out.print(n+" ");
+    public void sendMessage(String path, String msg) {
+        String s = TIMEFORMAT.format(new java.util.Date());
+        s += "OSC @ SEND_MSG to: " + path;
+        OscMessage oscmsg = new OscMessage(path);
+        s += ", ARGS: [ " + msg + " ]";
+        oscmsg.add(msg);
+        if (OSC != null) {
+            OSC.send(oscmsg, SUPERCOLLIDER);
+            System.out.println(s);
         }
-        System.out.println("]");
-        if (OSC != null)
-            OSC.fire(msg, SUPERCOLLIDER);
+        else System.err.println(s + " FAILED SENDING MESSAGE");
     }
-    */
 
     // Convenience method.
     public void sendMessage(String path) {
         sendMessage(path, new int[0]);
     }
 
-    public boolean getStatus() {
-        return connected;
+    public boolean getStatus(String s) {
+        return connected.get(s);
     }
 
     public Thread getStatusThread() {

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -63,10 +63,13 @@ public class OSC extends PApplet {
                 //System.out.println("PROCESS @ checkSC3Status started.");
                 System.out.println(s);
                 LambdaInterface resetPathStatus = (String p) -> {
-                    // reset status
-                    connected.put(p, false);
-                    // send message to see if OSCdef replies
-                    sendMessage(p, "status");
+                    // Some paths can be null since selected sonification does not use it.
+                    if(p!=null) {
+                        // reset status
+                        connected.put(p, false);
+                        // send message to see if OSCdef replies
+                        sendMessage(p, "status");
+                    }
                 };
                 while (!isInterrupted()) {
                     // Update sonification (has maybe been changed)

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -57,9 +57,9 @@ public class OSC extends PApplet {
         status = new Thread() {
             @Override
             public void run() {
-                String s = TIMEFORMAT.format(new java.util.Date());
-                s += "PROCESS @ checkSC3Status started.";
-                System.out.println(s);
+                String out = TIMEFORMAT.format(new java.util.Date());
+                out += "PROCESS @ checkSC3Status started.";
+                System.out.println(out);
                 LambdaInterface resetPathStatus = (String p) -> {
                     // reset status
                     connected.put(p, false);
@@ -88,9 +88,9 @@ public class OSC extends PApplet {
                         this.interrupt();
                     }
                 }
-                s = TIMEFORMAT.format(new java.util.Date());
-                s += "PROCESS @ checkSC3Status stopped.";
-                System.out.println(s);
+                out = TIMEFORMAT.format(new java.util.Date());
+                out += "PROCESS @ checkSC3Status stopped.";
+                System.out.println(out);
             }
         };
         status.start();
@@ -99,11 +99,18 @@ public class OSC extends PApplet {
     // Listen for messages.
     // NOTE we only expect status replies
     public void oscEvent(OscMessage msg) {
-        String s = TIMEFORMAT.format(new java.util.Date());
-        s += "OSC @ RECV_MSG: " + msg.addrPattern();
-        System.out.println(s);
         // SC3 will reply with path of received OSCdef
-        connected.put(msg.addrPattern(), true);
+        String key = msg.addrPattern();
+        String out = TIMEFORMAT.format(new java.util.Date());
+        if(connected.containsKey(key)) {
+            out += "OSC @ RECV_MSG: " + key;
+            System.out.println(out);
+            connected.put(key, true);
+        }
+        else {
+            out += "OSC @ RECV_MSG: ERROR: UNEXPECTED MESSAGE: " + key;
+            System.err.println(out);
+        }
     }
 
     /**
@@ -113,50 +120,50 @@ public class OSC extends PApplet {
      * @args arguments within osc message
      */
     public void sendMessage(String path, int[] args) {
-        String s = TIMEFORMAT.format(new java.util.Date());
-        s += "OSC @ SEND_MSG to: " + path;
+        String out = TIMEFORMAT.format(new java.util.Date());
+        out += "OSC @ SEND_MSG to: " + path;
         OscMessage msg = new OscMessage(path);
-        s += ", ARGS: [ ";
+        out += ", ARGS: [ ";
         for (int n : args) {
             msg.add(n);
-            s += n + " ";
+            out += n + " ";
         }
-        s += "]";
+        out += "]";
         if (OSC != null) {
             OSC.send(msg, SUPERCOLLIDER);
-            System.out.println(s);
+            System.out.println(out);
         }
-        else System.err.println(s + " FAILED SENDING MESSAGE");
+        else System.err.println(out + " FAILED SENDING MESSAGE");
     }
 
     public void sendMessage(String path, float[] args) {
-        String s = TIMEFORMAT.format(new java.util.Date());
-        s += "OSC @ SEND_MSG to: " + path;
+        String out = TIMEFORMAT.format(new java.util.Date());
+        out += "OSC @ SEND_MSG to: " + path;
         OscMessage msg = new OscMessage(path);
-        s += ", ARGS: [ ";
+        out += ", ARGS: [ ";
         for (float n : args) {
             msg.add(n);
-            s += n + " ";
+            out += n + " ";
         }
-        s += "]";
+        out += "]";
         if (OSC != null) {
             OSC.send(msg, SUPERCOLLIDER);
-            System.out.println(s);
+            System.out.println(out);
         }
-        else System.err.println(s + " FAILED SENDING MESSAGE");
+        else System.err.println(out + " FAILED SENDING MESSAGE");
     }
 
     public void sendMessage(String path, String msg) {
-        String s = TIMEFORMAT.format(new java.util.Date());
-        s += "OSC @ SEND_MSG to: " + path;
+        String out = TIMEFORMAT.format(new java.util.Date());
+        out += "OSC @ SEND_MSG to: " + path;
         OscMessage oscmsg = new OscMessage(path);
-        s += ", ARGS: [ " + msg + " ]";
+        out += ", ARGS: [ " + msg + " ]";
         oscmsg.add(msg);
         if (OSC != null) {
             OSC.send(oscmsg, SUPERCOLLIDER);
-            System.out.println(s);
+            System.out.println(out);
         }
-        else System.err.println(s + " FAILED SENDING MESSAGE");
+        else System.err.println(out + " FAILED SENDING MESSAGE");
     }
 
     // Convenience method.

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -59,33 +59,19 @@ public class OSC extends PApplet {
             public void run() {
                 String s = TIMEFORMAT.format(new java.util.Date());
                 s += "PROCESS @ checkSC3Status started.";
-                //System.out.print(TIMEFORMAT.format(new java.util.Date()));
-                //System.out.println("PROCESS @ checkSC3Status started.");
                 System.out.println(s);
                 LambdaInterface resetPathStatus = (String p) -> {
-                    // Some paths can be null since selected sonification does not use it.
-                    if(p!=null) {
-                        // reset status
-                        connected.put(p, false);
-                        // send message to see if OSCdef replies
-                        sendMessage(p, "status");
-                    }
+                    // reset status
+                    connected.put(p, false);
+                    // send message to see if OSCdef replies
+                    sendMessage(p, "status");
                 };
                 while (!isInterrupted()) {
                     // Update sonification (has maybe been changed)
                     Sonification sonification = Algosound.getInstance().getAlgorithm().getSelectedSonification();
-                    String[] paths = {sonification.STATUSPATH,
-                            sonification.STARTPATH,
-                            sonification.PAUSEPATH,
-                            sonification.RESUMEPATH,
-                            sonification.FREEPATH,
-                            sonification.BOOTPATH,
-                    };
+                    String[] paths = sonification.getPaths();
                     for(String p : paths) {
                         resetPathStatus.call(p);
-                    }
-                    for(String mod : sonification.MODPATHS) {
-                        resetPathStatus.call(mod);
                     }
                     /**
                      * TODO: This implementation depends on order of execution. If 1. connected gets
@@ -104,8 +90,6 @@ public class OSC extends PApplet {
                 }
                 s = TIMEFORMAT.format(new java.util.Date());
                 s += "PROCESS @ checkSC3Status stopped.";
-                //System.out.print(TIMEFORMAT.format(new java.util.Date()));
-                //System.out.println("PROCESS @ checkSC3Status stopped.");
                 System.out.println(s);
             }
         };

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -113,6 +113,7 @@ public class OSC extends PApplet {
         }
     }
 
+    // NOTE use `Object` as arg type so you only need one method?
     /**
      * Send a message to an osc listener with given path and arguments.
      *
@@ -120,6 +121,7 @@ public class OSC extends PApplet {
      * @args arguments within osc message
      */
     public void sendMessage(String path, int[] args) {
+        if(path==null) return;
         String out = TIMEFORMAT.format(new java.util.Date());
         out += "OSC @ SEND_MSG to: " + path;
         OscMessage msg = new OscMessage(path);
@@ -137,6 +139,7 @@ public class OSC extends PApplet {
     }
 
     public void sendMessage(String path, float[] args) {
+        if(path==null) return;
         String out = TIMEFORMAT.format(new java.util.Date());
         out += "OSC @ SEND_MSG to: " + path;
         OscMessage msg = new OscMessage(path);
@@ -154,6 +157,7 @@ public class OSC extends PApplet {
     }
 
     public void sendMessage(String path, String msg) {
+        if(path==null) return;
         String out = TIMEFORMAT.format(new java.util.Date());
         out += "OSC @ SEND_MSG to: " + path;
         OscMessage oscmsg = new OscMessage(path);
@@ -168,6 +172,7 @@ public class OSC extends PApplet {
 
     // Convenience method.
     public void sendMessage(String path) {
+        if(path==null) return;
         sendMessage(path, new int[0]);
     }
 

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -181,6 +181,10 @@ public class OSC extends PApplet {
         return connected.get(s);
     }
 
+    public Map<String, Boolean> getStatusMap() {
+        return connected;
+    }
+
     public Thread getStatusThread() {
         return status;
     }

--- a/src/algosound/data/audio/OSC.java
+++ b/src/algosound/data/audio/OSC.java
@@ -178,6 +178,7 @@ public class OSC extends PApplet {
     }
 
     public boolean getStatus(String s) {
+        if(connected.get(s) == null) return false;
         return connected.get(s);
     }
 

--- a/src/algosound/data/audio/Sonification.java
+++ b/src/algosound/data/audio/Sonification.java
@@ -156,17 +156,26 @@ public class Sonification {
         this.NAME = type.getName();
         this.uniquifyer = (String x) -> "/" + NAME.toLowerCase() + "_" + x + "_" + suffix;
         this.STARTPATH = uniquifyer.call("start");
-        this.PAUSEPATH = uniquifyer.call("pause");
-        this.RESUMEPATH = uniquifyer.call("resume");
+        // SCALE type does not have PAUSE, RESUME or FREE path
+        if(type == Type.SCALE) {
+            this.PAUSEPATH = null;
+            this.RESUMEPATH = null;
+            this.FREEPATH = null;
+        }
+        else {
+            this.PAUSEPATH = uniquifyer.call("pause");
+            this.RESUMEPATH = uniquifyer.call("resume");
+            this.FREEPATH = uniquifyer.call("free");
+        }
         this.MODPATHS = new ArrayList<String>();
         this.MODPATHS.add(uniquifyer.call("set"));
-        this.FREEPATH = uniquifyer.call("free");
         this.STATUSPATH = uniquifyer.call("hello");
         this.BOOTPATH = uniquifyer.call("boot");
         for(int i=0; i<wrappers.length; ++i) {
             wrappers[i].setPath(uniquifyer.call(wrappers[i].getPath()));
         }
         this.wrappers = wrappers;
+
     }
 
     /**

--- a/src/algosound/data/audio/Sonification.java
+++ b/src/algosound/data/audio/Sonification.java
@@ -1,18 +1,10 @@
 package algosound.data.audio;
 
 import algosound.data.algorithms.*;
-import algosound.ui.Algosound;
-import algosound.util.AlgosoundUtil;
-import controlP5.ControlP5;
-import controlP5.Controller;
-import controlP5.Knob;
-import algosound.data.audio.OSCFreqControllerWrapper.Type.*;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
-
-import static algosound.util.AlgosoundUtil.*;
 
 /**
  * Sonification class. This class is used in the implemented algorithms

--- a/src/algosound/data/audio/Sonification.java
+++ b/src/algosound/data/audio/Sonification.java
@@ -198,4 +198,23 @@ public class Sonification {
     public OSCControllerWrapper[] getWrappers() {
         return wrappers;
     }
+
+    // Return all used OSC paths
+    public String[] getPaths() {
+        ArrayList<String> paths = new ArrayList<>();
+        String[] defaultpaths = new String[]{STARTPATH, PAUSEPATH, RESUMEPATH, FREEPATH, STATUSPATH, BOOTPATH};
+        for(String p : defaultpaths) {
+            // Default paths can be null when they are not used
+            if(p!=null) {
+                paths.add(p);
+            }
+        }
+        for(String p : MODPATHS) {
+            paths.add(p);
+        }
+        for(OSCControllerWrapper w : wrappers)  {
+            paths.add(w.getPath());
+        }
+        return paths.toArray(new String[paths.size()]);
+    }
 }

--- a/src/algosound/data/audio/Sonification.java
+++ b/src/algosound/data/audio/Sonification.java
@@ -120,7 +120,7 @@ public class Sonification {
             new OSCControllerWrapper[]{
                     new OSCControllerWrapper("AMP","set_amp",0f,3f,0.2f),
                     new OSCControllerWrapper("FREQLAG","set_freqlag",0f,2f,0.1f),
-                    new OSCControllerWrapper("AMPLAG","set_freqlag",0f,5f,0.1f)
+                    new OSCControllerWrapper("AMPLAG","set_amplag",0f,5f,0.1f)
             },
             Quicksort.SUFFIX,
             new ArrayList<String>(Arrays.asList("set1","set2","set3"))

--- a/src/algosound/ui/Algosound.java
+++ b/src/algosound/ui/Algosound.java
@@ -303,14 +303,40 @@ public class Algosound extends PApplet {
         noStroke();
         fill(255);
         ellipse(10, 10, 10, 10);
+        String infolabel = "sc3 server";
+        Rectangle inforec = new Rectangle(10,5,(int)(10+textWidth(infolabel)), 10);
+        // Draw more info when mouse is over icon
+        if(mouseOver(inforec)) {
+            ellipse(10,25,10,10);
+        }
         if (OSC.getInstance().getStatus()) {
             fill(0, 255, 0);
         } else {
             fill(255, 0, 0);
         }
-        text("sc3 server", 20, 15);
+        text(infolabel, 20, 15);
         ellipse(10, 10, 8, 8);
         stroke(0);
+    }
+
+    // Check if mouse is over circle
+    private boolean mouseOver(int x, int y, int diameter) {
+        float disX = x - mouseX;
+        float disY = y - mouseY;
+        if(sqrt(sq(disX) + sq(disY)) < diameter/2 ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    // Check if mouse is over rectangle
+    private boolean mouseOver(Rectangle rec) {
+        if (mouseX >= rec.x && mouseX <= rec.x+rec.width &&
+                mouseY >= rec.y && mouseY <= rec.y+rec.height) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public Algorithm getAlgorithm() {

--- a/src/algosound/ui/Algosound.java
+++ b/src/algosound/ui/Algosound.java
@@ -309,7 +309,7 @@ public class Algosound extends PApplet {
         if(mouseOver(inforec)) {
             ellipse(10,25,10,10);
         }
-        if (OSC.getInstance().getStatus()) {
+        if (OSC.getInstance().getStatus(algorithm.getSelectedSonification().STATUSPATH)) {
             fill(0, 255, 0);
         } else {
             fill(255, 0, 0);

--- a/src/algosound/ui/Algosound.java
+++ b/src/algosound/ui/Algosound.java
@@ -301,34 +301,30 @@ public class Algosound extends PApplet {
     private void drawIPCStatus() {
         ellipseMode(CENTER);
         noStroke();
+        algosound.data.audio.Sonification selected = algorithm.getSelectedSonification();
         fill(255); // white for background ellipse
         int x = 10, y = 10, r = 10;
         ellipse(x, y, r, r); // STATUSPATH
         String infolabel = "sc3 server";
-        Rectangle inforec = new Rectangle(x,y-y/2,(int)(x+textWidth(infolabel)), r);
-        // Draw more info when mouse is over icon
-        algosound.data.audio.Sonification selected = algorithm.getSelectedSonification();
-        if(mouseOver(inforec)) {
-            int y_diff = 5, y2 = y + r + y_diff;
-            for(String p : OSC.getInstance().getStatusMap().keySet()) {
-                // skip STATUSPATH since it's always shown
-                if(p != selected.STATUSPATH) {
-                    ellipse(x, y2, r, r);
-                    y2 += r + y_diff;
-                }
-            }
-        }
         if (OSC.getInstance().getStatus(selected.STATUSPATH)) fill(0,255,0); else fill(255,0,0);
         text(infolabel, x+r, y+5);
         ellipse(x, y, r-2, r-2);
+        Rectangle inforec = new Rectangle(x,y-y/2,(int)(x+textWidth(infolabel)), r);
+        // Draw more info when mouse is over icon
         if(mouseOver(inforec)) {
             int y_diff = 5, y2 = y + r + y_diff;
             for(String p : OSC.getInstance().getStatusMap().keySet()) {
-                // skip STATUSPATH since it's always shown
-                if(p != selected.STATUSPATH) {
+                // skip STATUSPATH since it's always shown and only show status of paths of current selected sonification
+                if(p != selected.STATUSPATH && p.matches("^/" + selected.NAME.toLowerCase() + ".*$" )
+                        && p.matches(".*"+ algorithm.getSuffix() + "$")) {
+                    // draw black background
+                    fill(0);
+                    rect(x, y2-y/2-2, (int)(x+textWidth(p)), r+4);
+                    fill(255);
+                    ellipse(x, y2, r, r);
                     if(OSC.getInstance().getStatus(p)) fill(0,255,0); else fill(255,0,0);
                     ellipse(x, y2, r-2, r-2);
-                    text(p, x+r, y2+r);
+                    text(p, x+r, y2-5+r);
                     y2 += r + y_diff;
                 }
             }

--- a/src/algosound/ui/Algosound.java
+++ b/src/algosound/ui/Algosound.java
@@ -301,21 +301,38 @@ public class Algosound extends PApplet {
     private void drawIPCStatus() {
         ellipseMode(CENTER);
         noStroke();
-        fill(255);
-        ellipse(10, 10, 10, 10);
+        fill(255); // white for background ellipse
+        int x = 10, y = 10, r = 10;
+        ellipse(x, y, r, r); // STATUSPATH
         String infolabel = "sc3 server";
-        Rectangle inforec = new Rectangle(10,5,(int)(10+textWidth(infolabel)), 10);
+        Rectangle inforec = new Rectangle(x,y-y/2,(int)(x+textWidth(infolabel)), r);
         // Draw more info when mouse is over icon
+        algosound.data.audio.Sonification selected = algorithm.getSelectedSonification();
         if(mouseOver(inforec)) {
-            ellipse(10,25,10,10);
+            int y_diff = 5, y2 = y + r + y_diff;
+            for(String p : OSC.getInstance().getStatusMap().keySet()) {
+                // skip STATUSPATH since it's always shown
+                if(p != selected.STATUSPATH) {
+                    ellipse(x, y2, r, r);
+                    y2 += r + y_diff;
+                }
+            }
         }
-        if (OSC.getInstance().getStatus(algorithm.getSelectedSonification().STATUSPATH)) {
-            fill(0, 255, 0);
-        } else {
-            fill(255, 0, 0);
+        if (OSC.getInstance().getStatus(selected.STATUSPATH)) fill(0,255,0); else fill(255,0,0);
+        text(infolabel, x+r, y+5);
+        ellipse(x, y, r-2, r-2);
+        if(mouseOver(inforec)) {
+            int y_diff = 5, y2 = y + r + y_diff;
+            for(String p : OSC.getInstance().getStatusMap().keySet()) {
+                // skip STATUSPATH since it's always shown
+                if(p != selected.STATUSPATH) {
+                    if(OSC.getInstance().getStatus(p)) fill(0,255,0); else fill(255,0,0);
+                    ellipse(x, y2, r-2, r-2);
+                    text(p, x+r, y2+r);
+                    y2 += r + y_diff;
+                }
+            }
         }
-        text(infolabel, 20, 15);
-        ellipse(10, 10, 8, 8);
         stroke(0);
     }
 

--- a/src/algosound/ui/Algosound.java
+++ b/src/algosound/ui/Algosound.java
@@ -308,7 +308,7 @@ public class Algosound extends PApplet {
         } else {
             fill(255, 0, 0);
         }
-        text("SC3-server", 20, 15);
+        text("sc3 server", 20, 15);
         ellipse(10, 10, 8, 8);
         stroke(0);
     }

--- a/src/supercollider/bubblesort_scale.sc
+++ b/src/supercollider/bubblesort_scale.sc
@@ -46,7 +46,7 @@ SynthDef(\scale_default_midifade_BUBBLESORT, {
 // Define listener for boot sound.
 OSCdef(\scale_boot_OSC_BUBBLESORT, {
 	arg msg;
-	"\\scale_boot_OSC_BUBBLESORT".postln;
+	"\\scale_boot_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
 			~address.sendMsg("/scale_boot_BUBBLESORT");
@@ -98,7 +98,7 @@ OSCdef(\scale_boot_OSC_BUBBLESORT, {
 
 OSCdef(\scale_start_OSC_BUBBLESORT, {
 	arg msg;
-	"\\scale_start_OSC_BUBBLESORT".postln;
+	"\\scale_start_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
 			~address.sendMsg("/scale_start_BUBBLESORT");
@@ -138,7 +138,7 @@ OSCdef(\scale_set_minfreq_OSC_BUBBLESORT, {
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_BUBBLESORT, {
 	arg msg;
-	"\\scale_set_amp_OSC_BUBBLESORT - arguments: [";msg[1].post;"]".postln;
+	"\\scale_set_amp_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
 			~address.sendMsg("/scale_set_amp_BUBBLESORT");
@@ -153,6 +153,7 @@ OSCdef(\scale_set_amp_OSC_BUBBLESORT, {
 OSCdef(\scale_set_OSC_BUBBLESORT, {
 	arg msg;
 	var midi;
+	"\\scale_set_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
 			~address.sendMsg("/scale_set_BUBBLESORT");
@@ -163,10 +164,10 @@ OSCdef(\scale_set_OSC_BUBBLESORT, {
 				{ midi = (msg[1].cpsmidi.round)-1 },
 				{ midi = ~scales.at(i); },
 			);
+			"\\scale_set_OSC_BUBBLESORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
+			Synth(\scale_midisine_BUBBLESORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
 		}
 	);
-	"\\scale_set_OSC_BUBBLESORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
-	Synth(\scale_midisine_BUBBLESORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
 }, "/scale_set_BUBBLESORT");
 
 x = 0;

--- a/src/supercollider/bubblesort_scale.sc
+++ b/src/supercollider/bubblesort_scale.sc
@@ -7,6 +7,9 @@ Synth(\scale_default_midifade_BUBBLESORT);
 
 (//--Parentheses begin
 
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -42,9 +45,17 @@ SynthDef(\scale_default_midifade_BUBBLESORT, {
 
 // Define listener for boot sound.
 OSCdef(\scale_boot_OSC_BUBBLESORT, {
+	arg msg;
 	"\\scale_boot_OSC_BUBBLESORT".postln;
-	// Play boot sound
-	Synth(\scale_boot_BUBBLESORT);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_boot_BUBBLESORT");
+		},
+		{
+			// Play boot sound
+			Synth(\scale_boot_BUBBLESORT);
+		}
+	);
 }, "/scale_boot_BUBBLESORT");
 
 /**
@@ -86,53 +97,93 @@ OSCdef(\scale_boot_OSC_BUBBLESORT, {
 };
 
 OSCdef(\scale_start_OSC_BUBBLESORT, {
+	arg msg;
 	"\\scale_start_OSC_BUBBLESORT".postln;
-	~initscale;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_start_BUBBLESORT");
+		},
+		{
+			~initscale;
+		}
+	);
 }, "/scale_start_BUBBLESORT");
 
 OSCdef(\scale_set_maxfreq_OSC_BUBBLESORT, {
 	arg msg;
 	"\\scale_set_maxfreq_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_maxfreq_BUBBLESORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+		}
+	);
 }, "/scale_set_maxfreq_BUBBLESORT");
 
 OSCdef(\scale_set_minfreq_OSC_BUBBLESORT, {
 	arg msg;
 	"\\scale_set_minfreq_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_minfreq_BUBBLESORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+		}
+	);
 }, "/scale_set_minfreq_BUBBLESORT");
 
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_BUBBLESORT, {
 	arg msg;
 	"\\scale_set_amp_OSC_BUBBLESORT - arguments: [";msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_amp_BUBBLESORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/scale_set_amp_BUBBLESORT");
 
 // Define listener for playing a midi note.
 OSCdef(\scale_set_OSC_BUBBLESORT, {
 	arg msg;
 	var midi;
-	i = ~scales.find([msg[1].cpsmidi.round]);
-	if( i.isNil,
-		{ midi = (msg[1].cpsmidi.round)-1 },
-		{ midi = ~scales.at(i); },
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_BUBBLESORT");
+		},
+		{
+			i = ~scales.find([msg[1].cpsmidi.round]);
+			if( i.isNil,
+				{ midi = (msg[1].cpsmidi.round)-1 },
+				{ midi = ~scales.at(i); },
+			);
+		}
 	);
 	"\\scale_set_OSC_BUBBLESORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
 	Synth(\scale_midisine_BUBBLESORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
 }, "/scale_set_BUBBLESORT");
 
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
-
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\scale_status_OSC_BUBBLESORT, {
-	if(x==0,
-		{ Synth(\scale_boot_BUBBLESORT); x = 1; },
-		{}
+	arg msg;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_hello_BUBBLESORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\scale_boot_BUBBLESORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/scale_hello_BUBBLESORT");
 
 )//--Parentheses end

--- a/src/supercollider/bubblesort_wave.sc
+++ b/src/supercollider/bubblesort_wave.sc
@@ -117,7 +117,7 @@ OSCdef(\wave_set_OSC_BUBBLESORT, {
 OSCdef(\wave_set_freqlag_OSC_BUBBLESORT, {
 	arg msg;
 	"\\wave_set_freqlag_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	if(msg[1]=="status",
+	if(msg[1]=='status',
 		{
 			~address.sendMsg("/wave_set_freqlag_BUBBLESORT");
 		},

--- a/src/supercollider/bubblesort_wave.sc
+++ b/src/supercollider/bubblesort_wave.sc
@@ -11,6 +11,10 @@ y.set(\freqlag, 1)
 y.free
 
 (//--Parentheses begin
+
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -40,54 +44,114 @@ SynthDef(\wave_algowave_BUBBLESORT, {
 
 // Define listener for boot sound.
 OSCdef(\wave_boot_OSC_BUBBLESORT, {
-	"\\wave_boot_OSC_BUBBLESORT".postln;
-	Synth(\wave_boot_BUBBLESORT);
+	arg msg;
+	"\\wave_boot_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_boot_BUBBLESORT");
+		},
+		{
+			Synth(\wave_boot_BUBBLESORT);
+		}
+	);
 }, "/wave_boot_BUBBLESORT");
 
 // Define listener for start of algowave-synth.
 OSCdef(\wave_start_BUBBLESORT, {
-	"\\wave_start_BUBBLESORT".postln;
-	~algowave = Synth(\wave_algowave_BUBBLESORT);
+	arg msg;
+	"\\wave_start_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_start_BUBBLESORT");
+		},
+		{
+			~algowave = Synth(\wave_algowave_BUBBLESORT);
+		}
+	);
 }, "/wave_start_BUBBLESORT");
 
 // Define listener for pausing of algowave-synth.
 OSCdef(\wave_pause_OSC_BUBBLESORT, {
-	"\\wave_pause_OSC_BUBBLESORT".postln;
-	~algowave.set(\amptotal, 0);
+	arg msg;
+	"\\wave_pause_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pause_BUBBLESORT");
+		},
+		{
+			~algowave.set(\amptotal, 0);
+		}
+	);
 }, "/wave_pause_BUBBLESORT");
 
 // Define listener for resuming of algowave-synth.
 OSCdef(\wave_resume_OSC_BUBBLESORT, {
-	"\\wave_resume_OSC_BUBBLESORT".postln;
-	~algowave.set(\amptotal, ~amp);
+	arg msg;
+	"\\wave_resume_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_resume_BUBBLESORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_resume_BUBBLESORT");
 
 // Define listener for modifying.
 OSCdef(\wave_set_OSC_BUBBLESORT, {
 	arg msg;
 	"\\wave_set_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\freq, msg[1]);
-	~algowave.set(\amptotal, ~amp);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_BUBBLESORT");
+		},
+		{
+			~algowave.set(\freq, msg[1]);
+			~algowave.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_set_BUBBLESORT");
 
 // Realtime modulating of synths
 OSCdef(\wave_set_freqlag_OSC_BUBBLESORT, {
 	arg msg;
 	"\\wave_set_freqlag_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\freqlag, msg[1]);
+	if(msg[1]=="status",
+		{
+			~address.sendMsg("/wave_set_freqlag_BUBBLESORT");
+		},
+		{
+			~algowave.set(\freqlag, msg[1]);
+		}
+	);
 }, "/wave_set_freqlag_BUBBLESORT");
 
 ~amp = 1;
 OSCdef(\wave_set_amp_OSC_BUBBLESORT, {
 	arg msg;
 	"\\wave_set_amp_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amp_BUBBLESORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/wave_set_amp_BUBBLESORT");
 
 OSCdef(\wave_set_amplag_OSC_BUBBLESORT, {
 	arg msg;
 	"\\wave_set_amplag_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\amplag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amplag_BUBBLESORT");
+		},
+		{
+			~algowave.set(\amplag, msg[1]);
+		}
+	);
 }, "/wave_set_amplag_BUBBLESORT");
 /**
  * Define listener for freeing of synth.
@@ -101,22 +165,34 @@ OSCdef(\wave_set_amplag_OSC_BUBBLESORT, {
  * more severe bugs like orphaned synths.
  */
 OSCdef(\wave_free_OSC_BUBBLESORT, {
-	"\\wave_free_OSC_BUBBLESORT".postln;
-	// Free it using gate.
-	~algowave.set(\gate, 0);
+	arg msg;
+	"\\wave_free_OSC_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_free_BUBBLESORT");
+		},
+		{ // Free it using gate.
+			~algowave.set(\gate, 0);
+		}
+	);
 }, "/wave_free_BUBBLESORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\wave_status_OSC_BUBBLESORT, {
-	if(x==0,
-		{ Synth(\wave_boot_BUBBLESORT); x = 1; },
-		{}
+	arg msg;
+	"\\wave_hello_BUBBLESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_hello_BUBBLESORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\wave_boot_BUBBLESORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/wave_hello_BUBBLESORT");
 
 )//--Parentheses end

--- a/src/supercollider/insertionsort_scale.sc
+++ b/src/supercollider/insertionsort_scale.sc
@@ -190,7 +190,6 @@ OSCdef(\scale_status_OSC_INSERTIONSORT, {
 			);
 		}
 	);
-	~address.sendMsg("/hello");
 }, "/scale_hello_INSERTIONSORT");
 
 )//--Parentheses end

--- a/src/supercollider/insertionsort_scale.sc
+++ b/src/supercollider/insertionsort_scale.sc
@@ -142,7 +142,7 @@ OSCdef(\scale_set_minfreq_OSC_INSERTIONSORT, {
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_INSERTIONSORT, {
 	arg msg;
-	"\\scale_set_amp_OSC_INSERTIONSORT - arguments: [";msg[1].post;"]".postln;
+	"\\scale_set_amp_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
 			~address.sendMsg("/scale_set_amp_INSERTIONSORT");

--- a/src/supercollider/insertionsort_scale.sc
+++ b/src/supercollider/insertionsort_scale.sc
@@ -7,6 +7,9 @@ Synth(\scale_default_midifade_INSERTIONSORT);
 
 (//--Parentheses begin
 
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -42,9 +45,17 @@ SynthDef(\scale_default_midifade_INSERTIONSORT, {
 
 // Define listener for boot sound.
 OSCdef(\scale_boot_OSC_INSERTIONSORT, {
-	"playing boot sound.".postln;
-	// Play boot sound
-	Synth(\scale_boot_INSERTIONSORT);
+	arg msg;
+	"\\scale_boot_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_boot_INSERTIONSORT");
+		},
+		{
+			// Play boot sound
+			Synth(\scale_boot_INSERTIONSORT);
+		}
+	);
 }, "/scale_boot_INSERTIONSORT");
 
 /**
@@ -90,51 +101,94 @@ OSCdef(\scale_boot_OSC_INSERTIONSORT, {
  * Setup depends on given minimal frequency and max frequency.
  */
 OSCdef(\scale_start_OSC_INSERTIONSORT, {
-	"\\scale_start_OSC_INSERTIONSORT".postln;
-	~initscale;
+	arg msg;
+	"\\scale_start_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_start_INSERTIONSORT");
+		},
+		{
+			~initscale;
+		}
+	);
 }, "/scale_start_INSERTIONSORT");
 
 OSCdef(\scale_set_maxfreq_OSC_INSERTIONSORT, {
 	arg msg;
 	"\\scale_set_maxfreq_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_maxfreq_INSERTIONSORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+		}
+	);
 }, "/scale_set_maxfreq_INSERTIONSORT");
 
 OSCdef(\scale_set_minfreq_OSC_INSERTIONSORT, {
 	arg msg;
 	"\\scale_set_minfreq_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_minfreq_INSERTIONSORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+		}
+	);
 }, "/scale_set_minfreq_INSERTIONSORT");
 
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_INSERTIONSORT, {
 	arg msg;
 	"\\scale_set_amp_OSC_INSERTIONSORT - arguments: [";msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_amp_INSERTIONSORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/scale_set_amp_INSERTIONSORT");
 
 // Define listener for playing a midi note.
 OSCdef(\scale_set_OSC_INSERTIONSORT, {
 	arg msg;
 	var midi;
-	i = ~scales.find([msg[1].cpsmidi.round]);
-	if( i.isNil,
-		{ midi = (msg[1].cpsmidi.round)-1 },
-		{ midi = ~scales.at(i); },
+	"\\scale_set_OSC_INSERTIONSORT  - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_INSERTIONSORT");
+		},
+		{
+			i = ~scales.find([msg[1].cpsmidi.round]);
+			if( i.isNil,
+				{ midi = (msg[1].cpsmidi.round)-1 },
+				{ midi = ~scales.at(i); },
+			);
+			"\\scale_set_OSC_INSERTIONSORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
+			Synth(\scale_midisine_INSERTIONSORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
+		}
 	);
-	"\\scale_set_OSC_INSERTIONSORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
-	Synth(\scale_midisine_INSERTIONSORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
 }, "/scale_set_INSERTIONSORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\scale_status_OSC_INSERTIONSORT, {
-	if(x==0,
-		{ Synth(\scale_boot_INSERTIONSORT); x = 1; },
-		{}
+	arg msg;
+	"\\scale_status_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_hello_INSERTIONSORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\scale_boot_INSERTIONSORT); x = 1; },
+				{}
+			);
+		}
 	);
 	~address.sendMsg("/hello");
 }, "/scale_hello_INSERTIONSORT");

--- a/src/supercollider/insertionsort_wave.sc
+++ b/src/supercollider/insertionsort_wave.sc
@@ -177,7 +177,7 @@ OSCdef(\wave_set_amplag_OSC_INSERTIONSORT, {
 	"\\wave_set_amplag_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
-			~address.sendMsg("/wave_pulse_set_amplag_INSERTIONSORT");
+			~address.sendMsg("/wave_set_amplag_INSERTIONSORT");
 		},
 		{
 			~algowave.set(\amplag, msg[1]);
@@ -203,7 +203,7 @@ OSCdef(\wave_set_pulseamp_OSC_INSERTIONSORT, {
 	"\\wave_set_pulseamp_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
-			~address.sendMsg("/wave_pulse_set_amp_OSC_INSERTIONSORT");
+			~address.sendMsg("/wave_pulse_set_amp_INSERTIONSORT");
 		},
 		{
 			~insertamp = msg[1];
@@ -252,7 +252,6 @@ OSCdef(\wave_status_OSC_INSERTIONSORT, {
 			);
 		}
 	);
-	~address.sendMsg("/hello");
 }, "/wave_hello_INSERTIONSORT");
 
 )//--Parentheses end

--- a/src/supercollider/insertionsort_wave.sc
+++ b/src/supercollider/insertionsort_wave.sc
@@ -19,6 +19,10 @@ z.set(\gate, 0);
 z.free
 
 (//--Parentheses begin
+
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -65,72 +69,146 @@ SynthDef(\wave_insert_INSERTIONSORT, {
 
 // Define listener for boot sound.
 OSCdef(\wave_boot_OSC_INSERTIONSORT, {
-	"\\wave_boot_OSC_INSERTIONSORT".postln;
-	Synth(\boot);
+	arg msg;
+	"\\wave_boot_OSC_INSERTIONSORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_boot_INSERTIONSORT");
+		},
+		{
+			Synth(\boot);
+		}
+	);
 }, "/wave_boot_INSERTIONSORT");
 
 // Define listener for start of algowave- and insert-synth.
 OSCdef(\wave_start_OSC_INSERTIONSORT, {
-	"\\wave_start_OSC_INSERTIONSORT".postln;
-	~algowave = Synth(\wave_algowave_INSERTIONSORT);
-	~insert = Synth.after(~algowave,\wave_insert_INSERTIONSORT, [\amp, 0]);
+	arg msg;
+	"\\wave_start_OSC_INSERTIONSORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_start_INSERTIONSORT");
+		},
+		{
+			~algowave = Synth(\wave_algowave_INSERTIONSORT);
+			~insert = Synth.after(~algowave,\wave_insert_INSERTIONSORT, [\amp, 0]);
+		}
+	);
 }, "/wave_start_INSERTIONSORT");
 
 // Define listener for pausing of synths.
 OSCdef(\wave_pause_OSC_INSERTIONSORT, {
-	"\\wave_pause_OSC_INSERTIONSORT".postln;
-	~algowave.set(\amptotal, 0);
-	~insert.set(\amp, 0);
+	arg msg;
+	"\\wave_pause_OSC_INSERTIONSORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pause_INSERTIONSORT");
+		},
+		{
+			~algowave.set(\amptotal, 0);
+			~insert.set(\amp, 0);
+		}
+	);
 }, "/wave_pause_INSERTIONSORT");
 
 // Define listener for resuming of synths.
 OSCdef(\wave_resume_OSC_INSERTIONSORT, {
-	"\\wave_resume_OSC_INSERTIONSORT".postln;
-	~algowave.set(\amptotal, ~amp);
-	~insert.set(\amp, ~insertamp);
+	arg msg;
+	"\\wave_resume_OSC_INSERTIONSORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_resume_INSERTIONSORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+			~insert.set(\amp, ~insertamp);
+		}
+	);
 }, "/wave_resume_INSERTIONSORT");
 
 // Define listener for modifying.
 OSCdef(\wave_set_OSC_INSERTIONSORT, {
 	arg msg;
 	"\\wave_mod_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\amptotal, ~amp);
-	~insert.set(\amp, ~insertamp);
-	~algowave.set(\freq, msg[1]);
-	~insert.set(\freq, msg[2]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_INSERTIONSORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+			~insert.set(\amp, ~insertamp);
+			~algowave.set(\freq, msg[1]);
+			~insert.set(\freq, msg[2]);
+		}
+	);
 }, "/wave_set_INSERTIONSORT");
 
 // Realtime modulating of synths
 OSCdef(\wave_set_freqlag_OSC_INSERTIONSORT, {
 	arg msg;
-	"\\wave_mod_freqlag_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\freqlag, msg[1]);
+	"\\wave_set_freqlag_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_freqlag_INSERTIONSORT");
+		},
+		{
+			~algowave.set(\freqlag, msg[1]);
+		}
+	);
 }, "/wave_set_freqlag_INSERTIONSORT");
 
 ~amp = 1;
 ~insertamp = 0.2;
 OSCdef(\wave_set_amp_OSC_INSERTIONSORT, {
 	arg msg;
-	"\\wave_mod_amp_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~amp = msg[1];
+	"\\wave_set_amp_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amp_INSERTIONSORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/wave_set_amp_INSERTIONSORT");
 
 OSCdef(\wave_set_amplag_OSC_INSERTIONSORT, {
 	arg msg;
-	"\\wave_mod_amplag_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\amplag, msg[1]);
+	"\\wave_set_amplag_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pulse_set_amplag_INSERTIONSORT");
+		},
+		{
+			~algowave.set(\amplag, msg[1]);
+		}
+	);
 }, "/wave_set_amplag_INSERTIONSORT");
 
 OSCdef(\wave_set_pulsefreq_OSC_INSERTIONSORT, {
 	arg msg;
-	"\\wave_mod_pulsefreq_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~insert.set(\pulsefreq, msg[1]);
+	"\\wave_set_pulsefreq_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pulse_set_freq_INSERTIONSORT");
+		},
+		{
+			~insert.set(\pulsefreq, msg[1]);
+		}
+	);
 }, "/wave_pulse_set_freq_INSERTIONSORT");
 
 OSCdef(\wave_set_pulseamp_OSC_INSERTIONSORT, {
 	arg msg;
-	"\\wave_mod_pulseamp_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~insertamp = msg[1];
+	"\\wave_set_pulseamp_OSC_INSERTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pulse_set_amp_OSC_INSERTIONSORT");
+		},
+		{
+			~insertamp = msg[1];
+		}
+	);
 }, "/wave_pulse_set_amp_INSERTIONSORT");
 /**
  * Define listener for freeing of synth.
@@ -144,21 +222,35 @@ OSCdef(\wave_set_pulseamp_OSC_INSERTIONSORT, {
  * more severe bugs like orphaned synths.
  */
 OSCdef(\wave_free_OSC_INSERTIONSORT, {
-	"\\wave_free_OSC_INSERTIONSORT".postln;
-	// Free it using gate.
-	~algowave.set(\gate, 0);
-	~insert.set(\gate, 0);
+	arg msg;
+	"\\wave_free_OSC_INSERTIONSORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_free_INSERTIONSORT");
+		},
+		{
+			// Free it using gate.
+			~algowave.set(\gate, 0);
+			~insert.set(\gate, 0);
+		}
+	);
 }, "/wave_free_INSERTIONSORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\wave_status_OSC_INSERTIONSORT, {
-	if(x==0,
-		{ Synth(\wave_boot_INSERTIONSORT); x = 1; },
-		{}
+	arg msg;
+	"\\wave_status_OSC_INSERTIONSORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_hello_INSERTIONSORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\wave_boot_INSERTIONSORT); x = 1; },
+				{}
+			);
+		}
 	);
 	~address.sendMsg("/hello");
 }, "/wave_hello_INSERTIONSORT");

--- a/src/supercollider/mergesort_scale.sc
+++ b/src/supercollider/mergesort_scale.sc
@@ -139,7 +139,7 @@ OSCdef(\scale_set_minfreq_OSC_MERGESORT, {
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_MERGESORT, {
 	arg msg;
-	"\\scale_set_amp_OSC_MERGESORT - arguments: [";msg[1].post;"]".postln;
+	"\\scale_set_amp_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
 	if(msg[1]=='status',
 		{
 			~address.sendMsg("/scale_set_amp_MERGESORT");

--- a/src/supercollider/mergesort_scale.sc
+++ b/src/supercollider/mergesort_scale.sc
@@ -7,6 +7,9 @@ Synth(\scale_default_midifade_MERGESORT);
 
 (//--Parentheses begin
 
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -42,16 +45,27 @@ SynthDef(\scale_default_midifade_MERGESORT, {
 
 // Define listener for boot sound.
 OSCdef(\scale_boot_OSC_MERGESORT, {
-	"playing boot sound.".postln;
-	// Play boot sound
-	Synth(\scale_boot_MERGESORT);
+	arg msg;
+	"\\scale_boot_OSC_MERGESORT - arguments [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_boot_MERGESORT");
+		},
+		{
+			// Play boot sound
+			Synth(\scale_boot_MERGESORT);
+		}
+	);
 }, "/scale_boot_MERGESORT");
+
 
 /**
  * Define listener for setting up of scale.
  * Setup depends on given minimal frequency and max frequency.
  */
-OSCdef(\scale_start_OSC_MERGESORT, {
+~minfreq = 200;
+~maxfreq = 4000;
+~initscale = {
 	arg msg;
 	var min_freq, max_freq, min_midi, max_midi;
 
@@ -67,7 +81,9 @@ OSCdef(\scale_start_OSC_MERGESORT, {
 		|i|
 		~scales = ~scales ++ (Scale.minor.degrees+(min_midi+(12*i)));
 	};
-	"scales=".post;~scales.postln;
+	~minfreq = min_freq;
+	~maxfreq = max_freq;
+	"~initscale: scales=".post;~scales.postln;
 
 	/**
 	 * Generate a random sequence of duration times.
@@ -79,52 +95,98 @@ OSCdef(\scale_start_OSC_MERGESORT, {
 		Array.fill(6,{ arg i; (i*0.25) + 0.25;}).choose
 	}); // Array.fill inception
 	"durations=".post;~durations.postln;*/
+};
+
+OSCdef(\scale_start_OSC_MERGESORT, {
+	arg msg;
+	"\\scale_start_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_start_MERGESORT");
+		},
+		{
+			~initscale;
+		}
+	);
 }, "/scale_start_MERGESORT");
 
 OSCdef(\scale_set_maxfreq_OSC_MERGESORT, {
 	arg msg;
 	"\\scale_set_maxfreq_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_maxfreq_MERGESORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+		}
+	);
 }, "/scale_set_maxfreq_MERGESORT");
 
 OSCdef(\scale_set_minfreq_OSC_MERGESORT, {
 	arg msg;
 	"\\scale_set_minfreq_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_minfreq_MERGESORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+		}
+	);
 }, "/scale_set_minfreq_MERGESORT");
 
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_MERGESORT, {
 	arg msg;
 	"\\scale_set_amp_OSC_MERGESORT - arguments: [";msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_amp_MERGESORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/scale_set_amp_MERGESORT");
 
 // Define listener for playing a midi note.
 OSCdef(\scale_set_OSC_MERGESORT, {
 	arg msg;
 	var midi;
-	i = ~scales.find([msg[1].cpsmidi.round]);
-	if( i.isNil,
-		{ midi = (msg[1].cpsmidi.round)-1 },
-		{ midi = ~scales.at(i); },
+	"\\scale_set_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_MERGESORT");
+		},
+		{
+			i = ~scales.find([msg[1].cpsmidi.round]);
+			if( i.isNil,
+				{ midi = (msg[1].cpsmidi.round)-1 },
+				{ midi = ~scales.at(i); },
+			);
+			"\\scale_set_OSC_MERGESORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
+			Synth(\scale_midisine_MERGESORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
+		}
 	);
-	"playing midi-note ".post;midi.postln;
-	"pan=".post;msg[2].postln;
-	Synth(\scale_midisine_MERGESORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
 }, "/scale_set_MERGESORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\scale_status_OSC_MERGESORT, {
-	if(x==0,
-		{ Synth(\scale_boot_MERGESORT); x = 1; },
-		{}
+	arg msg;
+	"\\scale_status_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_hello_MERGESORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\scale_boot_MERGESORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/scale_hello_MERGESORT");
 
 )//--Parentheses end

--- a/src/supercollider/mergesort_wave.sc
+++ b/src/supercollider/mergesort_wave.sc
@@ -11,6 +11,10 @@ y.set(\freqlag, 1)
 y.free
 
 (//--Parentheses begin
+
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -40,53 +44,114 @@ SynthDef(\wave_algowave_MERGESORT, {
 
 // Define listener for boot sound.
 OSCdef(\wave_boot_OSC_MERGESORT, {
-	"playing boot sound.".postln;
-	Synth(\wave_boot_MERGESORT);
+	arg msg;
+	"\\wave_boot_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_boot_MERGESORT");
+		},
+		{
+			Synth(\wave_boot_MERGESORT);
+		}
+	);
 }, "/wave_boot_MERGESORT");
 
 // Define listener for start of algowave-synth.
 OSCdef(\wave_start_OSC_MERGESORT, {
-	"creating algowave.".postln;
-	~algowave = Synth(\wave_algowave_MERGESORT);
+	arg msg;
+	"\\wave_start_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_start_MERGESORT");
+		},
+		{
+			~algowave = Synth(\wave_algowave_MERGESORT);
+		}
+	);
 }, "/wave_start_MERGESORT");
 
 // Define listener for pausing of algowave-synth.
 OSCdef(\wave_pause_OSC_MERGESORT, {
-	"pausing algowave.".postln;
-	~algowave.set(\amptotal, 0);
+	arg msg;
+	"\\wave_pause_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pause_MERGESORT");
+		},
+		{
+			~algowave.set(\amptotal, 0);
+		}
+	);
 }, "/wave_pause_MERGESORT");
 
 // Define listener for resuming of algowave-synth.
 OSCdef(\wave_resume_OSC_MERGESORT, {
-	"resuming algowave.".postln;
-	~algowave.set(\amptotal, ~amp);
+	arg msg;
+	"\\wave_resume_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_resume_MERGESORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_resume_MERGESORT");
 
 // Define listener for modifying.
 OSCdef(\wave_set_OSC_MERGESORT, {
 	arg msg;
-	~algowave.set(\amptotal, ~amp);
-	~algowave.set(\freq, msg[1]);
+	"\\wave_set_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_MERGESORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+			~algowave.set(\freq, msg[1]);
+		}
+	);
 }, "/wave_set_MERGESORT");
 
 // Realtime modulating of synths
 OSCdef(\wave_set_freqlag_OSC_MERGESORT, {
 	arg msg;
 	"\\wave_set_freqlag_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\freqlag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_freqlag_MERGESORT");
+		},
+		{
+			~algowave.set(\freqlag, msg[1]);
+		}
+	);
 }, "/wave_set_freqlag_MERGESORT");
 
 ~amp = 1;
 OSCdef(\wave_set_amp_OSC_MERGESORT, {
 	arg msg;
 	"\\wave_set_amp_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amp_MERGESORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/wave_set_amp_MERGESORT");
 
 OSCdef(\wave_set_amplag_OSC_MERGESORT, {
 	arg msg;
 	"\\wave_set_amplag_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\amplag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amplag_MERGESORT");
+		},
+		{
+			~algowave.set(\amplag, msg[1]);
+		}
+	);
 }, "/wave_set_amplag_MERGESORT");
 /**
  * Define listener for freeing of synth.
@@ -100,22 +165,35 @@ OSCdef(\wave_set_amplag_OSC_MERGESORT, {
  * more severe bugs like orphaned synths.
  */
 OSCdef(\wave_free_OSC_MERGESORT, {
-	"freeing algowave.".postln;
-	// Free it using gate.
-	~algowave.set(\gate, 0);
+	arg msg;
+	"\\wave_free_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_free_MERGESORT");
+		},
+		{
+			// Free it using gate.
+			~algowave.set(\gate, 0);
+		}
+	);
 }, "/wave_free_MERGESORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\wave_status_OSC_MERGESORT, {
-	if(x==0,
-		{ Synth(\wave_boot_MERGESORT); x = 1; },
-		{}
+	arg msg;
+	"\\wave_status_OSC_MERGESORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_hello_MERGESORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\wave_boot_MERGESORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/wave_hello_MERGESORT");
 
 )//--Parentheses end

--- a/src/supercollider/quicksort_wave.sc
+++ b/src/supercollider/quicksort_wave.sc
@@ -11,6 +11,10 @@ y.set(\freqlag, 1)
 y.free
 
 (//--Parentheses begin
+
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -40,69 +44,146 @@ SynthDef(\wave_algowave_QUICKSORT, {
 
 // Define listener for boot sound.
 OSCdef(\wave_boot_OSC_QUICKSORT, {
-	"playing boot sound.".postln;
-	Synth(\wave_boot_QUICKSORT);
+	arg msg;
+	"\\wave_boot_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_boot_QUICKSORT");
+		},
+		{
+			Synth(\wave_boot_QUICKSORT);
+		}
+	);
 }, "/wave_boot_QUICKSORT");
 
 // Define listener for start of synths.
 OSCdef(\wave_start_OSC_QUICKSORT, {
-	"creating multiple algowaves".postln;
-	~algowave1 = Synth(\wave_algowave_QUICKSORT);
-	~algowave2 = Synth(\wave_algowave_QUICKSORT);
-	~algowave3 = Synth(\wave_algowave_QUICKSORT);
+	arg msg;
+	"\\wave_start_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_start_QUICKSORT");
+		},
+		{
+			~algowave1 = Synth(\wave_algowave_QUICKSORT);
+			~algowave2 = Synth(\wave_algowave_QUICKSORT);
+			~algowave3 = Synth(\wave_algowave_QUICKSORT);
+		}
+	);
 }, "/wave_start_QUICKSORT");
 
 // Define listener for pausing of synths.
 OSCdef(\wave_pause_OSC_QUICKSORT, {
-	"pausing synths.".postln;
-	~algowave1.set(\amptotal, 0);
-	~algowave2.set(\amptotal, 0);
-	~algowave3.set(\amptotal, 0);
+	arg msg;
+	"\\wave_pause_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pause_QUICKSORT");
+		},
+		{
+			~algowave1.set(\amptotal, 0);
+			~algowave2.set(\amptotal, 0);
+			~algowave3.set(\amptotal, 0);
+		}
+	);
 }, "/wave_pause_QUICKSORT");
 
 // Define listener for resuming of synths.
 OSCdef(\wave_resume_OSC_QUICKSORT, {
-	"resuming synths.".postln;
-	~algowave1.set(\amptotal, ~amp);
-	~algowave2.set(\amptotal, ~amp);
-	~algowave3.set(\amptotal, ~amp);
+	arg msg;
+	"\\wave_resume_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_resume_QUICKSORT");
+		},
+		{
+			~algowave1.set(\amptotal, ~amp);
+			~algowave2.set(\amptotal, ~amp);
+			~algowave3.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_resume_QUICKSORT");
 
 // Define listeners for modifying.
 OSCdef(\wave_set1_OSC_QUICKSORT, {
 	arg msg;
-	~algowave1.set(\freq, msg[1]);
-	~algowave1.set(\amptotal, ~amp);
+	"\\wave_set1_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set1_QUICKSORT");
+		},
+		{
+			~algowave1.set(\freq, msg[1]);
+			~algowave1.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_set1_QUICKSORT");
 OSCdef(\wave_set2_OSC_QUICKSORT, {
 	arg msg;
-	~algowave2.set(\freq, msg[1]);
-	~algowave2.set(\amptotal, ~amp);
+	"\\wave_set2_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set2_QUICKSORT");
+		},
+		{
+			~algowave2.set(\freq, msg[1]);
+			~algowave2.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_set2_QUICKSORT");
 OSCdef(\wave_set3_OSC_QUICKSORT, {
 	arg msg;
-	~algowave3.set(\freq, msg[1]);
-	~algowave3.set(\amptotal, ~amp);
+	"\\wave_set3_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set3_QUICKSORT");
+		},
+		{
+			~algowave3.set(\freq, msg[1]);
+			~algowave3.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_set3_QUICKSORT");
 
 // Realtime modulating of synths
 OSCdef(\wave_set_freqlag_OSC_QUICKSORT, {
 	arg msg;
 	"\\wave_set_freqlag_OSC_QUICKSORTT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\freqlag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_freqlag_QUICKSORT");
+		},
+		{
+			~algowave.set(\freqlag, msg[1]);
+		}
+	);
 }, "/wave_set_freqlag_QUICKSORT");
 
 ~amp = 1;
 OSCdef(\wave_set_amp_OSC_QUICKSORT, {
 	arg msg;
 	"\\wave_set_amp_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amp_QUICKSORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/wave_set_amp_QUICKSORT");
 
 OSCdef(\wave_set_amplag_OSC_QUICKSORT, {
 	arg msg;
 	"\\wave_set_amplag_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\amplag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amplag_QUICKSORT");
+		},
+		{
+			~algowave.set(\amplag, msg[1]);
+		}
+	);
 }, "/wave_set_amplag_QUICKSORT");
 /**
  * Define listener for freeing of synths.
@@ -116,24 +197,37 @@ OSCdef(\wave_set_amplag_OSC_QUICKSORT, {
  * more severe bugs like orphaned synths.
  */
 OSCdef(\wave_free_OSC_QUICKSORT, {
-	"freeing synths.".postln;
-	// Free it using gate.
-	~algowave1.set(\gate, 0);
-	~algowave2.set(\gate, 0);
-	~algowave3.set(\gate, 0);
+	arg msg;
+	"\\wave_free_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_free_QUICKSORT");
+		},
+		{
+			// Free it using gate.
+			~algowave1.set(\gate, 0);
+			~algowave2.set(\gate, 0);
+			~algowave3.set(\gate, 0);
+		}
+	);
 }, "/wave_free_QUICKSORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\wave_status_OSC_QUICKSORT, {
-	if(x==0,
-		{ Synth(\wave_boot_QUICKSORT); x = 1; },
-		{}
+	arg msg;
+	"\\wave_status_OSC_QUICKSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_hello_QUICKSORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\wave_boot_QUICKSORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/wave_hello_QUICKSORT");
 
 )//--Parentheses end

--- a/src/supercollider/selectionsort_scale.sc
+++ b/src/supercollider/selectionsort_scale.sc
@@ -7,6 +7,9 @@ Synth(\scale_default_midifade_SELECTIONSORT);
 
 (//--Parentheses begin
 
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -42,9 +45,17 @@ SynthDef(\scale_default_midifade_SELECTIONSORT, {
 
 // Define listener for boot sound.
 OSCdef(\scale_boot_OSC_SELECTIONSORT, {
-	"playing boot sound.".postln;
-	// Play boot sound
-	Synth(\scale_boot_SELECTIONSORT);
+	arg msg;
+	"\\scale_boot_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_boot_SELECTIONSORT");
+		},
+		{
+			// Play boot sound
+			Synth(\scale_boot_SELECTIONSORT);
+		}
+	);
 }, "/scale_boot_SELECTIONSORT");
 
 /**
@@ -86,54 +97,95 @@ OSCdef(\scale_boot_OSC_SELECTIONSORT, {
 };
 
 OSCdef(\scale_start_OSC_SELECTIONSORT, {
-	"\\scale_start_OSC_SELECTIONSORT".postln;
-	~initscale;
+	arg msg;
+	"\\scale_start_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_start_SELECTIONSORT");
+		},
+		{
+			~initscale;
+		}
+	);
 }, "/scale_start_SELECTIONSORT");
 
 OSCdef(\scale_set_maxfreq_OSC_SELECTIONSORT, {
 	arg msg;
 	"\\scale_set_maxfreq_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_maxfreq_SELECTIONSORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], ~minfreq, msg[1]]);
+		}
+	);
 }, "/scale_set_maxfreq_SELECTIONSORT");
 
 OSCdef(\scale_set_minfreq_OSC_SELECTIONSORT, {
 	arg msg;
 	"\\scale_set_minfreq_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_minfreq_SELECTIONSORT");
+		},
+		{
+			~initscale.value(msg: [msg[0], msg[1], ~maxfreq]);
+		}
+	);
 }, "/scale_set_minfreq_SELECTIONSORT");
 
 ~amp = 0.1;
 OSCdef(\scale_set_amp_OSC_SELECTIONSORT, {
 	arg msg;
-	"\\scale_set_amp_OSC_SELECTIONSORT - arguments: [";msg[1].post;"]".postln;
-	~amp = msg[1];
+	"\\scale_set_amp_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_amp_SELECTIONSORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/scale_set_amp_SELECTIONSORT");
 
 // Define listener for playing a midi note.
 OSCdef(\scale_set_OSC_SELECTIONSORT, {
 	arg msg;
 	var midi;
-	i = ~scales.find([msg[1].cpsmidi.round]);
-	if( i.isNil,
-		{ midi = (msg[1].cpsmidi.round)-1 },
-		{ midi = ~scales.at(i); },
+	"\\scale_set_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_set_SELECTIONSORT");
+		},
+		{
+			i = ~scales.find([msg[1].cpsmidi.round]);
+			if( i.isNil,
+				{ midi = (msg[1].cpsmidi.round)-1 },
+				{ midi = ~scales.at(i); },
+			);
+			"\\scale_set_OSC_SELECTIONSORT - arguments: [\midi: ".post;midi.post;", \pan: ".post;msg[2].post;", amp: ".post;~amp.post;"]".postln;
+			Synth(\scale_midisine_SELECTIONSORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
+		}
 	);
-	"playing midi-note ".post;midi.postln;
-	"pan=".post;msg[2].postln;
-	Synth(\scale_midisine_SELECTIONSORT, [\midi, midi, \rel, rrand(0.1,1.75), \pan, msg[2], \amp, ~amp]);
 }, "/scale_set_SELECTIONSORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\scale_status_OSC_SELECTIONSORT, {
-	if(x==0,
-		{ Synth(\scale_boot_SELECTIONSORT); x = 1; },
-		{}
+	arg msg;
+	"\\scale_status_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/scale_hello_SELECTIONSORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\scale_boot_SELECTIONSORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/scale_hello_SELECTIONSORT");
 
 )//--Parentheses end

--- a/src/supercollider/selectionsort_wave.sc
+++ b/src/supercollider/selectionsort_wave.sc
@@ -12,6 +12,10 @@ y.free
 z = Synth(\wave_minimum_SELECTIONSORT);
 
 (//--Parentheses begin
+
+// Create address to fire messages to Processing client
+~address = NetAddr.new("127.0.0.1", 12000);
+
 /**
  * Futuristic booting sound.
  */
@@ -57,65 +61,141 @@ SynthDef(\wave_minimum_SELECTIONSORT, {
 
 // Define listener for boot sound.
 OSCdef(\wave_boot_OSC_SELECTIONSORT, {
-	"playing boot sound.".postln;
-	Synth(\wave_boot_SELECTIONSORT);
+	arg msg;
+	"\\wave_boot_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_boot_SELECTIONSORT");
+		},
+		{
+			Synth(\wave_boot_SELECTIONSORT);
+		}
+	);
 }, "/wave_boot_SELECTIONSORT");
 
 // Define listener for start of algowave-synth.
 OSCdef(\wave_start_OSC_SELECTIONSORT, {
-	"creating synths.".postln;
-	~algowave = Synth(\wave_algowave_SELECTIONSORT);
+	arg msg;
+	"\\wave_start_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_start_SELECTIONSORT");
+		},
+		{
+			~algowave = Synth(\wave_algowave_SELECTIONSORT);
+		}
+	);
 }, "/wave_start_SELECTIONSORT");
 
 // Define listener for pausing of algowave-synth.
 OSCdef(\wave_pause_OSC_SELECTIONSORT, {
-	"pausing sound.".postln;
-	~algowave.set(\amptotal, 0);
+	arg msg;
+	"\\wave_pause_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_pause_SELECTIONSORT");
+		},
+		{
+			~algowave.set(\amptotal, 0);
+		}
+	);
 }, "/wave_pause_SELECTIONSORT");
 
 // Define listener for resuming of algowave-synth.
 OSCdef(\wave_resume_OSC_SELECTIONSORT, {
-	"resuming sound.".postln;
-	~algowave.set(\amptotal, ~amp);
+	arg msg;
+	"\\wave_resume_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_resume_SELECTIONSORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+		}
+	);
 }, "/wave_resume_SELECTIONSORT");
 
 // Define listener for modifying.
 OSCdef(\wave_set_OSC_SELECTIONSORT, {
 	arg msg;
-	~algowave.set(\amptotal, ~amp);
-	~algowave.set(\freq, msg[1]);
+	"\\wave_set_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_SELECTIONSORT");
+		},
+		{
+			~algowave.set(\amptotal, ~amp);
+			~algowave.set(\freq, msg[1]);
+		}
+	);
 }, "/wave_set_SELECTIONSORT");
 
 OSCdef(\wave_min_set_OSC_SELECTIONSORT, {
 	arg msg;
-	Synth(\wave_minimum_SELECTIONSORT, [\amp, ~minamp, \freq, msg[1]]);
+	"\\wave_min_set_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_min_set_SELECTIONSORT");
+		},
+		{
+			Synth(\wave_minimum_SELECTIONSORT, [\amp, ~minamp, \freq, msg[1]]);
+		}
+	);
 }, "/wave_min_set_SELECTIONSORT");
 
 // Realtime modulating of synths
 OSCdef(\wave_set_freqlag_OSC_SELECTIONSORT, {
 	arg msg;
 	"\\wave_set_freqlag_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\freqlag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_freqlag_SELECTIONSORT");
+		},
+		{
+			~algowave.set(\freqlag, msg[1]);
+		}
+	);
 }, "/wave_set_freqlag_SELECTIONSORT");
 
 ~amp = 1;
 OSCdef(\wave_set_amp_OSC_SELECTIONSORT, {
 	arg msg;
 	"\\wave_set_amp_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~amp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amp_SELECTIONSORT");
+		},
+		{
+			~amp = msg[1];
+		}
+	);
 }, "/wave_set_amp_SELECTIONSORT");
 
 OSCdef(\wave_set_amplag_OSC_SELECTIONSORT, {
 	arg msg;
 	"\\wave_set_amplag_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~algowave.set(\amplag, msg[1]);
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_set_amplag_SELECTIONSORT");
+		},
+		{
+			~algowave.set(\amplag, msg[1]);
+		}
+	);
 }, "/wave_set_amplag_SELECTIONSORT");
 
 ~minamp = 0.2;
 OSCdef(\wave_min_set_amp_OSC_SELECTIONSORT, {
 	arg msg;
 	"\\wave_min_set_amp_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
-	~minamp = msg[1];
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_min_set_amp_SELECTIONSORT");
+		},
+		{
+			~minamp = msg[1];
+		}
+	);
 }, "/wave_min_set_amp_SELECTIONSORT");
 
 /**
@@ -130,22 +210,35 @@ OSCdef(\wave_min_set_amp_OSC_SELECTIONSORT, {
  * more severe bugs like orphaned synths.
  */
 OSCdef(\wave_free_OSC_SELECTIONSORT, {
-	"freeing synths.".postln;
-	// Free it using gate.
-	~algowave.set(\gate, 0);
+	arg msg;
+	"\\wave_free_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_free_SELECTIONSORT");
+		},
+		{
+			// Free it using gate.
+			~algowave.set(\gate, 0);
+		}
+	);
 }, "/wave_free_SELECTIONSORT");
-
-// Create address to fire messages to Processing client
-~address = NetAddr.new("127.0.0.1", 12000);
 
 x = 0;
 // Define listener for checking if sc3-server is running.
 OSCdef(\wave_status_OSC_SELECTIONSORT, {
-	if(x==0,
-		{ Synth(\wave_boot_SELECTIONSORT); x = 1; },
-		{}
+	arg msg;
+	"\\wave_status_OSC_SELECTIONSORT - arguments: [".post;msg[1].post;"]".postln;
+	if(msg[1]=='status',
+		{
+			~address.sendMsg("/wave_hello_SELECTIONSORT");
+		},
+		{
+			if(x==0,
+				{ Synth(\wave_boot_SELECTIONSORT); x = 1; },
+				{}
+			);
+		}
 	);
-	~address.sendMsg("/hello");
 }, "/wave_hello_SELECTIONSORT");
 
 )//--Parentheses end


### PR DESCRIPTION
This PR will close #7 when merged.

Comments about implementation:
- Hovering over top left status reveals verbose status
- Verbose status consists of **all** used paths for OSCdefs. This means the OSC controller paths are also included in this!
- Status of paths show up as the path itself. Can maybe disorient users but the colors should be clear enough to indicate when everything is okay / something is wrong.
- In class `OSC`, added sending of messages to all paths every second just like checking status of the server. *This increased console output by a lot! Rethink output messages?*
- Updated every `OSCdef` of every .sc file to check if `'status'` string was received and then send back a response which identifies the `OSCdef` so we know that it's responding.

Comments to think about in the future:
- Checking every path every second is pretty annoying. But if we don't check often enough, the status can be green "too long" before it is updated to show when server went down => Trade-off between responsiveness of status and performance.